### PR TITLE
Add cancelable property to DOM event

### DIFF
--- a/src/feform.js
+++ b/src/feform.js
@@ -163,11 +163,11 @@ export default class Form extends Component {
     };
 
     submit = () => {
-        this.form.dispatchEvent(new Event('submit'));
+        this.form.dispatchEvent(new Event('submit', {cancelable: true}));
     };
 
     reset = () => {
-        this.form.dispatchEvent(new Event('reset'));
+        this.form.dispatchEvent(new Event('reset', {cancelable: true}));
     };
 
     render() {


### PR DESCRIPTION
Currently in Firefox the page reloads when user submits a form, to prevent this we explicitly set the cancelable property on the Event to be true. 